### PR TITLE
do not print *default* for exported nameless class declarations

### DIFF
--- a/src/formatted-codegen.js
+++ b/src/formatted-codegen.js
@@ -530,7 +530,7 @@ export class ExtensibleCodeGen {
   }
 
   reduceClassDeclaration(node, {name, super: _super, elements}) {
-    let state = seq(this.t("class"), this.sep(Sep.BEFORE_CLASS_NAME), name);
+    let state = seq(this.t("class"), node.name.name === "*default*" ? empty() : seq(this.sep(Sep.BEFORE_CLASS_NAME), name));
     if (_super != null) {
       state = seq(state, this.sep(Sep.BEFORE_EXTENDS), this.t("extends"), this.sep(Sep.AFTER_EXTENDS), _super);
     }

--- a/src/minimal-codegen.js
+++ b/src/minimal-codegen.js
@@ -206,7 +206,7 @@ export default class MinimalCodeGen {
   }
 
   reduceClassDeclaration(node, {name, super: _super, elements}) {
-    let state = seq(t("class"), name);
+    let state = seq(t("class"), node.name.name === "*default*" ? empty() : name);
     if (_super != null) {
       state = seq(state, t("extends"), _super);
     }

--- a/test/simple.js
+++ b/test/simple.js
@@ -835,6 +835,7 @@ describe("Code generator", function () {
       test("export default 0;0");
       test("export default function f(){}");
       test("export default function*f(){}");
+      test("export default class{}");
       test("export default class A{}");
       test("export default(class{})");
       test("export default(function(){})");


### PR DESCRIPTION
Fixes #35 
