### PR TITLE
Fix #42: codegen 'a/i' as 'a/i', not 'a/ i'

### DIFF
--- a/src/coderep.js
+++ b/src/coderep.js
@@ -189,13 +189,14 @@ export class Empty extends CodeRep {
 }
 
 export class Token extends CodeRep {
-  constructor(token) {
+  constructor(token, isRegExp = false) {
     super();
     this.token = token;
+    this.isRegExp = isRegExp;
   }
 
   emit(ts) {
-    ts.put(this.token);
+    ts.put(this.token, this.isRegExp);
   }
 }
 

--- a/src/formatted-codegen.js
+++ b/src/formatted-codegen.js
@@ -338,8 +338,8 @@ export class ExtensibleCodeGen {
     return original;
   }
 
-  t(token) {
-    return new Token(token);
+  t(token, isRegExp = false) {
+    return new Token(token, isRegExp);
   }
 
   p(node, precedence, a) {
@@ -875,7 +875,7 @@ export class ExtensibleCodeGen {
   }
 
   reduceLiteralRegExpExpression(node) {
-    return this.t(`/${node.pattern}/${node.global ? 'g' : ''}${node.ignoreCase ? 'i' : ''}${node.multiLine ? 'm' : ''}${node.unicode ? 'u' : ''}${node.sticky ? 'y' : ''}`);
+    return this.t(`/${node.pattern}/${node.global ? 'g' : ''}${node.ignoreCase ? 'i' : ''}${node.multiLine ? 'm' : ''}${node.unicode ? 'u' : ''}${node.sticky ? 'y' : ''}`, true);
   }
 
   reduceLiteralStringExpression(node) {

--- a/src/minimal-codegen.js
+++ b/src/minimal-codegen.js
@@ -6,8 +6,8 @@ function p(node, precedence, a) {
   return getPrecedence(node) < precedence ? paren(a) : a;
 }
 
-function t(token) {
-  return new Token(token);
+function t(token, isRegExp = false) {
+  return new Token(token, isRegExp);
 }
 
 function paren(rep) {
@@ -541,7 +541,7 @@ export default class MinimalCodeGen {
   }
 
   reduceLiteralRegExpExpression(node) {
-    return t(`/${node.pattern}/${node.global ? 'g' : ''}${node.ignoreCase ? 'i' : ''}${node.multiLine ? 'm' : ''}${node.unicode ? 'u' : ''}${node.sticky ? 'y' : ''}`);
+    return t(`/${node.pattern}/${node.global ? 'g' : ''}${node.ignoreCase ? 'i' : ''}${node.multiLine ? 'm' : ''}${node.unicode ? 'u' : ''}${node.sticky ? 'y' : ''}`, true);
   }
 
   reduceLiteralStringExpression(node) {

--- a/src/token_stream.js
+++ b/src/token_stream.js
@@ -47,6 +47,7 @@ export class TokenStream {
     this.lastNumber = null;
     this.lastChar = null;
     this.optionalSemi = false;
+    this.previousWasRegExp = false;
   }
 
   putNumber(number) {
@@ -59,7 +60,7 @@ export class TokenStream {
     this.optionalSemi = true;
   }
 
-  put(tokenStr) {
+  put(tokenStr, isRegExp) {
     if (this.optionalSemi) {
       this.optionalSemi = false;
       if (tokenStr !== "}") {
@@ -78,11 +79,14 @@ export class TokenStream {
     let rightChar = tokenStr.charAt(0);
     let lastChar = this.lastChar;
     this.lastChar = tokenStr.charAt(tokenStr.length - 1);
+    let previousWasRegExp = this.previousWasRegExp;
+    this.previousWasRegExp = isRegExp;
     if (lastChar &&
         ((lastChar == "+" || lastChar == "-") &&
         lastChar == rightChar ||
         code.isIdentifierPartES6(lastChar.charCodeAt(0)) && code.isIdentifierPartES6(rightChar.charCodeAt(0)) ||
-        lastChar == "/" && (rightChar == "i" || rightChar == "/"))) {
+        lastChar == "/" && rightChar == "/" ||
+        previousWasRegExp && rightChar == "i")) {
       this.result += " ";
     }
 

--- a/test/simple.js
+++ b/test/simple.js
@@ -450,6 +450,8 @@ describe("Code generator", function () {
       test("(a+b)%c");
       test("!a*b");
       test("a*(b+c)");
+
+      test("a/i");
     });
 
     it("PrefixExpression", function () {
@@ -508,6 +510,7 @@ describe("Code generator", function () {
       test("/a\\r/gi");
       test("/a\\r/ instanceof 3");
       test("/a\\r/g instanceof 3");
+      test("/a/ in 0");
     });
 
     it("LiteralBooleanExpression", function () {


### PR DESCRIPTION
By tracking whether or not the last token emitted as a regular expression. We could instead track the type of the previous token, but that would be way more work and, I think, otherwise unnecessary.
