### PR TITLE
Parenthesize exponential expressions properly

### DIFF
--- a/src/formatted-codegen.js
+++ b/src/formatted-codegen.js
@@ -454,7 +454,8 @@ export class ExtensibleCodeGen {
     let startsWithLetSquareBracket = left.startsWithLetSquareBracket;
     let startsWithFunctionOrClass = left.startsWithFunctionOrClass;
     let leftContainsIn = left.containsIn;
-    if (getPrecedence(node.left) < getPrecedence(node)) {
+    let isRightAssociative = node.operator === "**";
+    if (getPrecedence(node.left) < getPrecedence(node) || isRightAssociative && (getPrecedence(node.left) === getPrecedence(node) || node.left.type === "UnaryExpression")) {
       leftCode = this.paren(leftCode, Sep.EXPRESSION_PAREN_BEFORE, Sep.EXPRESSION_PAREN_AFTER);
       startsWithCurly = false;
       startsWithLetSquareBracket = false;
@@ -463,7 +464,7 @@ export class ExtensibleCodeGen {
     }
     let rightCode = right;
     let rightContainsIn = right.containsIn;
-    if (getPrecedence(node.right) <= getPrecedence(node)) {
+    if (getPrecedence(node.right) < getPrecedence(node) || !isRightAssociative && (getPrecedence(node.right) === getPrecedence(node))) {
       rightCode = this.paren(rightCode, Sep.EXPRESSION_PAREN_BEFORE, Sep.EXPRESSION_PAREN_AFTER);
       rightContainsIn = false;
     }

--- a/src/minimal-codegen.js
+++ b/src/minimal-codegen.js
@@ -124,7 +124,8 @@ export default class MinimalCodeGen {
     let startsWithLetSquareBracket = left.startsWithLetSquareBracket;
     let startsWithFunctionOrClass = left.startsWithFunctionOrClass;
     let leftContainsIn = left.containsIn;
-    if (getPrecedence(node.left) < getPrecedence(node)) {
+    let isRightAssociative = node.operator === "**";
+    if (getPrecedence(node.left) < getPrecedence(node) || isRightAssociative && (getPrecedence(node.left) === getPrecedence(node) || node.left.type === "UnaryExpression")) {
       leftCode = paren(leftCode);
       startsWithCurly = false;
       startsWithLetSquareBracket = false;
@@ -133,7 +134,7 @@ export default class MinimalCodeGen {
     }
     let rightCode = right;
     let rightContainsIn = right.containsIn;
-    if (getPrecedence(node.right) <= getPrecedence(node)) {
+    if (getPrecedence(node.right) < getPrecedence(node) || !isRightAssociative && (getPrecedence(node.right) === getPrecedence(node))) {
       rightCode = paren(rightCode);
       rightContainsIn = false;
     }

--- a/test/simple.js
+++ b/test/simple.js
@@ -454,6 +454,20 @@ describe("Code generator", function () {
       test("a/i");
     });
 
+    it("Exponential", function () {
+      test("a**b");
+      test("(a**b)**c");
+      test("a**b**c");
+      test("a*b**c");
+      test("(a*b)**c");
+      test("a**b*c");
+      test("a**(b*c)");
+      test("(-a)**b");
+      test("-(a**b)")
+      test("(void a)**b")
+      test("void(a**b)")
+    });
+
     it("PrefixExpression", function () {
       test("+a");
       test("-a");


### PR DESCRIPTION
Fixes `(-a)**b` (#51), `a**b**c`, and `(a**b)**c`.
