### PR TITLE
Parenthesize 'let' in the LHS of for-in

### DIFF
--- a/src/formatted-codegen.js
+++ b/src/formatted-codegen.js
@@ -685,19 +685,9 @@ export class ExtensibleCodeGen {
   }
 
   reduceForInStatement(node, {left, right, body}) {
-    let leftP = left;
-    switch (node.left.type) {
-      case "VariableDeclaration":
-        leftP = noIn(markContainsIn(left));
-        break;
-      case "AssignmentTargetIdentifier":
-        if (node.left.name === "let") {
-          leftP = this.paren(left, Sep.FOR_IN_LET_PAREN_BEFORE, Sep.FOR_IN_LET_PAREN_BEFORE);
-        }
-        break;
-    }
+    left = node.left.type === "VariableDeclaration" ? noIn(markContainsIn(left)) : left;
     return objectAssign(
-      seq(this.t("for"), this.sep(Sep.AFTER_FORIN_FOR), this.paren(seq(leftP, this.sep(Sep.BEFORE_FORIN_IN), this.t("in"), this.sep(Sep.AFTER_FORIN_FOR), right), Sep.FOR_IN_PAREN_BEFORE, Sep.FOR_IN_PAREN_AFTER), this.sep(Sep.BEFORE_FORIN_BODY), body, this.sep(Sep.AFTER_STATEMENT(node))),
+      seq(this.t("for"), this.sep(Sep.AFTER_FORIN_FOR), this.paren(seq(left.startsWithLet ? this.paren(left, Sep.FOR_IN_LET_PAREN_BEFORE, Sep.FOR_IN_LET_PAREN_AFTER) : left, this.sep(Sep.BEFORE_FORIN_IN), this.t("in"), this.sep(Sep.AFTER_FORIN_FOR), right), Sep.FOR_IN_PAREN_BEFORE, Sep.FOR_IN_PAREN_AFTER), this.sep(Sep.BEFORE_FORIN_BODY), body, this.sep(Sep.AFTER_STATEMENT(node))),
       {endsWithMissingElse: body.endsWithMissingElse});
   }
 

--- a/src/minimal-codegen.js
+++ b/src/minimal-codegen.js
@@ -354,19 +354,9 @@ export default class MinimalCodeGen {
   }
 
   reduceForInStatement(node, {left, right, body}) {
-    let leftP = left;
-    switch (node.left.type) {
-      case "VariableDeclaration":
-        leftP = noIn(markContainsIn(left));
-        break;
-      case "AssignmentTargetIdentifier":
-        if (node.left.name === "let") {
-          leftP = paren(left);
-        }
-        break;
-    }
+    left = node.left.type === "VariableDeclaration" ? noIn(markContainsIn(left)) : left;
     return objectAssign(
-      seq(t("for"), paren(seq(leftP, t("in"), right)), body),
+      seq(t("for"), paren(seq(left.startsWithLet ? paren(left) : left, t("in"), right)), body),
       {endsWithMissingElse: body.endsWithMissingElse});
   }
 

--- a/test/simple.js
+++ b/test/simple.js
@@ -637,6 +637,7 @@ describe("Code generator", function () {
 
     it("ForOfStatement", function () {
       test("for(a of b);");
+      test("for(a of(1,2));");
       test("for([a]of[b]);");
       test("for(let[a]of[b]);");
       testScript("for((let)of b);");
@@ -755,6 +756,11 @@ describe("Code generator", function () {
       test("for(var a in 1);");
       testScript("for((let)in 1);");
       test("for(a in 1);");
+      test("for(a in 1,2);");
+      testScript("for((let)in b);");
+      testScript("for((let.a)in b);");
+      testScript("for((let[a])in b);");
+      test2Script("for((let.a)in b);", "for((let).a in b);");
     });
 
     it("ForStatement", function () {


### PR DESCRIPTION
Fixes #57.

Not sure how this was missed. For-of is done properly; this PR just makes for-in use the same logic as for-of, instead of completely different and also incorrect logic.