### PR TITLE
Add shift-parser-expectations

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "mocha --inline-diffs --check-leaks --ui tdd --reporter dot --timeout 5000 --recursive test",
     "build": "babel --source-maps-inline --out-dir dist src",
     "lint": "eslint src test",
-    "prepare": "rm -rf dist/* && npm update && npm run build"
+    "prepare": "rm -rf dist/* && npm run build"
   },
   "dependencies": {
     "babel-eslint": "^8.2.2",
@@ -32,7 +32,7 @@
     "everything.js": "^1.0.3",
     "expect.js": "0.3.1",
     "mocha": "2.2.5",
-    "shift-parser": "5.0.0"
+    "shift-parser": "5.2.3"
   },
   "keywords": [
     "Shift",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "everything.js": "^1.0.3",
     "expect.js": "0.3.1",
     "mocha": "2.2.5",
+    "shift-parser-expectations": "2016.0.1",
     "shift-parser": "5.2.3"
   },
   "keywords": [

--- a/test/simple.js
+++ b/test/simple.js
@@ -537,7 +537,6 @@ describe('Code generator', () => {
 
     it('LiteralNullExpression', () => {
       testModule('null');
-      test2('null', 'nul\\u006c');
     });
 
     it('FunctionDeclaration', () => {

--- a/test/test262/expectations.js
+++ b/test/test262/expectations.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  xfail: [
+    // unicode surrogate pairs: https://github.com/shapesecurity/shift-codegen-js/issues/69
+    '08358cb4732d8ce1.js-tree.json',
+    '4d2c7020de650d40.js-tree.json',
+    '5c3d125ce5f032aa.js-tree.json',
+    'da9e16ac9fd5b61d.js-tree.json',
+    'dc6037a43bed9588.js-tree.json',
+    'f5b89028dfa29f27.js-tree.json',
+    'f7f611e6fdb5b9fc.js-tree.json',
+
+    // html comments: https://github.com/shapesecurity/shift-codegen-js/issues/68
+    '4c3a394af4d281d1.js-tree.json',
+    'f96c694c5a2f2be9.js-tree.json',
+  ],
+};

--- a/test/test262/run.js
+++ b/test/test262/run.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const parseScript = require('shift-parser').parseScript;
+const parseModule = require('shift-parser').parseModule;
+const codegen = require('../..');
+const fs = require('fs');
+const path = require('path');
+const expect = require('expect.js');
+
+const testExpectations = require('./expectations');
+
+const treesDir = 'node_modules/shift-parser-expectations/expectations';
+
+
+function assertSuccessfulCodegen(expectedTree, parse) {
+  const rendered = codegen.default(expectedTree);
+  const actualTree = parse(rendered);
+  expect(expectedTree).to.eql(actualTree);
+
+  const formattedRendered = codegen.default(expectedTree, new codegen.FormattedCodeGen);
+  const formattedActualTree = parse(formattedRendered);
+  expect(expectedTree).to.eql(formattedActualTree);
+}
+
+describe('test262', () => {
+  const achievedFailures = [];
+  for (const f of fs.readdirSync(treesDir).filter(name => /tree.json$/.test(name))) {
+    const json = fs.readFileSync(path.join(treesDir, f), 'utf8');
+    const tree = JSON.parse(json, (k, v) => k === 'loc' ? void 0 : v);
+
+    try {
+      assertSuccessfulCodegen(tree, /module.js/.test(f) ? parseModule : parseScript);
+    } catch (e) {
+      if (testExpectations.xfail.indexOf(f) !== -1) {
+        achievedFailures.push(f);
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  for (const f of testExpectations.xfail) {
+    if (achievedFailures.indexOf(f) === -1) {
+      throw new Error('Marked as xfailed, but didn\'t fail: ' + f);
+    }
+  }
+});


### PR DESCRIPTION
This asserts every valid AST in shift-parser-expectations round-trips through `x => parse(codegen(x))`. Some don't, and are xfailed.

Also updates the dev-dependency on shift-parser, removes `npm update` (wtf) from `prepare`, and removes an invalid test.