### PR TITLE
Add CodeGenWithLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ import codegen from "shift-codegen";
 let programSource = codegen(/* Shift format AST */);
 ```
 
+Location information is available in environments which support WeakMap via an alternative interface:
+```js
+let tree = parseScript('foo(); bar;');
+
+import { codeGenWithLocation } from "shift-codegen";
+let { source, locations } = codeGenWithLocation(tree);
+source; // 'foo();bar';
+locations.get(tree.statements[0].expression); // { start: { line: 1, column: 0, offset: 0 }, end: { line: 1, column: 5, offset: 5 } }
+```
+
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-codegen",
-  "version": "5.0.5",
+  "version": "5.1.0",
   "description": "code generator for Shift format ASTs",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-codegen-js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-eslint": "^8.2.2",
     "esutils": "^2.0.2",
     "object-assign": "^4.1.0",
-    "shift-reducer": "^4.0.0"
+    "shift-reducer": "^4.3.0"
   },
   "devDependencies": {
     "babel-cli": "6.3.13",
@@ -33,7 +33,7 @@
     "expect.js": "0.3.1",
     "mocha": "2.2.5",
     "shift-parser-expectations": "2016.0.1",
-    "shift-parser": "5.2.3"
+    "shift-parser": "5.2.4"
   },
   "keywords": [
     "Shift",

--- a/src/coderep.js
+++ b/src/coderep.js
@@ -208,6 +208,17 @@ export class Token extends CodeRep {
   }
 }
 
+export class RawToken extends CodeRep {
+  constructor(token) {
+    super();
+    this.token = token;
+  }
+
+  emit(ts) {
+    ts.putRaw(this.token);
+  }
+}
+
 export class NumberCodeRep extends CodeRep {
   constructor(number) {
     super();

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import reduce from 'shift-reducer';
-import { TokenStream } from './token_stream';
+import { TokenStream } from './token-stream';
 import MinimalCodeGen from './minimal-codegen';
 
 export default function codeGen(script, generator = new MinimalCodeGen) {
@@ -12,3 +12,4 @@ export default function codeGen(script, generator = new MinimalCodeGen) {
 export { default as MinimalCodeGen } from './minimal-codegen';
 export { ExtensibleCodeGen, FormattedCodeGen, Sep } from './formatted-codegen';
 export { Precedence, getPrecedence, escapeStringLiteral, CodeRep, Empty, Token, NumberCodeRep, Paren, Bracket, Brace, NoIn, ContainsIn, Seq, Semi, CommaSep, SemiOp } from './coderep';
+export { default as codeGenWithLocation } from './with-location';

--- a/src/token-stream.js
+++ b/src/token-stream.js
@@ -16,11 +16,8 @@
 
 import { code } from 'esutils';
 
-function numberDot(fragment) {
-  if (fragment.indexOf('.') < 0 && fragment.indexOf('e') < 0 && fragment.indexOf('x') < 0) {
-    return '..';
-  }
-  return '.';
+export function needsDoubleDot(fragment) {
+  return fragment.indexOf('.') < 0 && fragment.indexOf('e') < 0 && fragment.indexOf('x') < 0;
 }
 
 function renderNumber(n) {
@@ -62,16 +59,22 @@ export class TokenStream {
     this.optionalSemi = true;
   }
 
+  putRaw(tokenStr) {
+    this.result += tokenStr;
+  }
+
   put(tokenStr, isRegExp) {
     if (this.optionalSemi) {
       this.optionalSemi = false;
       if (tokenStr !== '}') {
-        this.put(';');
+        this.result += ';';
+        this.lastChar = ';';
+        this.previousWasRegExp = false;
       }
     }
     if (this.lastNumber !== null && tokenStr.length === 1) {
       if (tokenStr === '.') {
-        this.result += numberDot(this.lastNumber);
+        this.result += needsDoubleDot(this.lastNumber) ? '..' : '.';
         this.lastNumber = null;
         this.lastChar = '.';
         return;

--- a/src/with-location.js
+++ b/src/with-location.js
@@ -1,0 +1,158 @@
+import { reduce, adapt } from 'shift-reducer';
+import { TokenStream, needsDoubleDot } from './token-stream';
+import MinimalCodeGen from './minimal-codegen';
+
+function mightHaveSemi(type) {
+  return /(Import)|(Export)|(Statement)|(Directive)|(SwitchCase)|(SwitchDefault)/.test(type);
+}
+
+class TokenStreamWithLocation extends TokenStream {
+  constructor() {
+    super();
+    this.line = 1;
+    this.column = 0;
+    this.startingNodes = [];
+    this.finishingStatements = [];
+    this.lastNumberNode = null;
+    this.locations = new WeakMap;
+  }
+
+  putRaw(tokenStr) {
+    let previousLength = this.result.length;
+    super.putRaw(tokenStr);
+    this.startNodes(tokenStr, previousLength);
+  }
+
+  put(tokenStr, isRegExp) {
+    if (this.optionalSemi && tokenStr !== '}') {
+      for (let obj of this.finishingStatements) {
+        ++obj.end.column;
+        ++obj.end.offset;
+      }
+    }
+    this.finishingStatements = [];
+
+    if (this.lastNumber !== null && tokenStr === '.' && needsDoubleDot(this.lastNumber)) {
+      let loc = this.locations.get(this.lastNumberNode).end;
+      ++loc.column;
+      ++loc.offset;
+    }
+    this.lastNumberNode = null;
+
+    let previousLength = this.result.length;
+    super.put(tokenStr, isRegExp);
+    this.startNodes(tokenStr, previousLength);
+  }
+
+  startNodes(tokenStr, previousLength) {
+    let linebreakRegex = /\r\n?|[\n\u2028\u2029]/g;
+    let matched = false;
+    let match;
+    let startLine = this.line;
+    let startColumn = this.column;
+    while ((match = linebreakRegex.exec(tokenStr))) {
+      ++this.line;
+      this.column = tokenStr.length - match.index - match[0].length;
+      matched = true;
+    }
+
+    if (!matched) {
+      this.column += this.result.length - previousLength;
+      startColumn = this.column - tokenStr.length; // i.e., skip past any additional characters which were necessitated by, but not part of, this part
+    }
+    for (const node of this.startingNodes) {
+      this.locations.set(node, {
+        start: {
+          line: startLine,
+          column: startColumn,
+          offset: this.result.length - tokenStr.length,
+        },
+        end: null,
+      });
+    }
+    this.startingNodes = [];
+  }
+
+  startEmit(node) {
+    this.startingNodes.push(node);
+  }
+
+  finishEmit(node) {
+    this.locations.get(node).end = {
+      line: this.line,
+      column: this.column,
+      offset: this.result.length,
+    };
+    if (mightHaveSemi(node.type)) {
+      this.finishingStatements.push(this.locations.get(node));
+    }
+  }
+}
+
+function addLocation(rep, node) {
+  const originalEmit = rep.emit.bind(rep);
+  if (node.type === 'Script' || node.type === 'Module') {
+    // These are handled specially: they include beginning and trailing whitespace.
+    rep.emit = (ts, ...args) => {
+      ts.locations.set(node, {
+        start: {
+          line: 1,
+          column: 0,
+          offset: 0,
+        },
+        end: null,
+      });
+      originalEmit(ts, ...args);
+      ts.locations.get(node).end = {
+        line: ts.line,
+        column: ts.column,
+        offset: ts.result.length,
+      };
+    };
+  } else if (node.type === 'LiteralNumericExpression') {
+    rep.emit = (ts, ...args) => {
+      ts.startEmit(node);
+      originalEmit(ts, ...args);
+      ts.finishEmit(node);
+      ts.lastNumberNode = node;
+    };
+  } else {
+    rep.emit = (ts, ...args) => {
+      ts.startEmit(node);
+      originalEmit(ts, ...args);
+      ts.finishEmit(node);
+    };
+  }
+  return rep;
+}
+
+function addLocationToReducer(reducer) {
+  const wrapped = adapt(addLocation, reducer);
+
+  const originalRegenerate = wrapped.regenerateArrowParams.bind(wrapped);
+  wrapped.regenerateArrowParams = function (element, original) {
+    const out = originalRegenerate(element, original);
+    if (out !== original) {
+      addLocation(out, element);
+    }
+    return out;
+  };
+
+  const originalDirective = wrapped.parenToAvoidBeingDirective.bind(wrapped);
+  wrapped.parenToAvoidBeingDirective = function (element, original) {
+    const out = originalDirective(element, original);
+    if (out !== original) {
+      addLocation(out, element);
+    }
+    return out;
+  };
+
+  return wrapped;
+}
+
+export default function codeGenWithLocation(program, generator = new MinimalCodeGen) {
+  let ts = new TokenStreamWithLocation;
+  let rep = reduce(addLocationToReducer(generator), program);
+  rep.emit(ts);
+  return { source: ts.result, locations: ts.locations };
+}

--- a/test/simple.js
+++ b/test/simple.js
@@ -528,6 +528,7 @@ describe('Code generator', () => {
       testModule('/a\\r/ instanceof 3');
       testModule('/a\\r/g instanceof 3');
       testModule('/a/ in 0');
+      testModule('/a/;i');
     });
 
     it('LiteralBooleanExpression', () => {

--- a/test/test262/run.js
+++ b/test/test262/run.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const parseScript = require('shift-parser').parseScript;
-const parseModule = require('shift-parser').parseModule;
+const parseScriptWithLocation = require('shift-parser').parseScriptWithLocation;
+const parseModuleWithLocation = require('shift-parser').parseModuleWithLocation;
 const codegen = require('../..');
 const fs = require('fs');
 const path = require('path');
@@ -12,36 +12,66 @@ const testExpectations = require('./expectations');
 const treesDir = 'node_modules/shift-parser-expectations/expectations';
 
 
+function assertLocationsEqual(expectedNode, actualNode, expectedLocations, actualLocations) {
+  if (expectedLocations.has(expectedNode) && actualLocations.has(actualNode)) {
+    expect(actualLocations.get(actualNode)).to.eql(expectedLocations.get(expectedNode));
+  } else if (expectedLocations.has(expectedNode)) {
+    throw new Error('unexpectedly missing ' + expectedNode.type);
+  } else if (actualLocations.has(actualNode)) {
+    throw new Error('unexpectedly has ' + actualNode.type);
+  }
+
+  for (let key of Object.keys(expectedNode)) {
+    let child = expectedNode[key];
+    if (Array.isArray(child)) {
+      for (let i = 0; i < child.length; ++i) {
+        if (typeof child[i] !== 'object' || child[i] == null) {
+          continue;
+        }
+        assertLocationsEqual(child[i], actualNode[key][i], expectedLocations, actualLocations);
+      }
+    } else if (typeof child === 'object' && child != null) {
+      assertLocationsEqual(child, actualNode[key], expectedLocations, actualLocations);
+    }
+  }
+}
+
 function assertSuccessfulCodegen(expectedTree, parse) {
-  const rendered = codegen.default(expectedTree);
-  const actualTree = parse(rendered);
-  expect(expectedTree).to.eql(actualTree);
+  const codegened = codegen.codeGenWithLocation(expectedTree);
+  const parsed = parse(codegened.source);
+  expect(expectedTree).to.eql(parsed.tree);
+
+  assertLocationsEqual(parsed.tree, expectedTree, parsed.locations, codegened.locations);
+
 
   const formattedRendered = codegen.default(expectedTree, new codegen.FormattedCodeGen);
-  const formattedActualTree = parse(formattedRendered);
+  const formattedActualTree = parse(formattedRendered).tree;
   expect(expectedTree).to.eql(formattedActualTree);
 }
 
-describe('test262', () => {
+suite('test262', () => {
   const achievedFailures = [];
   for (const f of fs.readdirSync(treesDir).filter(name => /tree.json$/.test(name))) {
     const json = fs.readFileSync(path.join(treesDir, f), 'utf8');
     const tree = JSON.parse(json, (k, v) => k === 'loc' ? void 0 : v);
 
-    try {
-      assertSuccessfulCodegen(tree, /module.js/.test(f) ? parseModule : parseScript);
-    } catch (e) {
-      if (testExpectations.xfail.indexOf(f) !== -1) {
-        achievedFailures.push(f);
-        continue;
+    test(`round-trips through x => parse(codegen(x)) [${f}]`, () => {
+      try {
+        assertSuccessfulCodegen(tree, /module.js/.test(f) ? parseModuleWithLocation : parseScriptWithLocation);
+      } catch (e) {
+        if (testExpectations.xfail.indexOf(f) !== -1) {
+          achievedFailures.push(f);
+          return;
+        }
+        throw e;
       }
-      throw e;
-    }
+    });
   }
 
-  for (const f of testExpectations.xfail) {
-    if (achievedFailures.indexOf(f) === -1) {
-      throw new Error('Marked as xfailed, but didn\'t fail: ' + f);
+  test('xfails', () => {
+    const unexpectedlyPassed = testExpectations.xfail.filter(f => achievedFailures.indexOf(f) === -1);
+    if (unexpectedlyPassed.length > 0) {
+      throw new Error('Marked as xfailed, but didn\'t fail: ' + JSON.stringify(unexpectedlyPassed, null, '  '));
     }
-  }
+  });
 });


### PR DESCRIPTION
Fixes #55.

~This adds a runtime dependency on `shift-spec`, which maybe isn't ideal, but I don't think it's that bad.~ No longer true.

Commits have been organized for ease of reviewing (you know, relatively speaking).