### PR TITLE
track let-ness of calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-codegen",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-codegen",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "code generator for Shift format ASTs",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-codegen-js",

--- a/src/formatted-codegen.js
+++ b/src/formatted-codegen.js
@@ -611,6 +611,7 @@ export class ExtensibleCodeGen {
       seq(this.p(node.callee, getPrecedence(node), callee), this.sep(Sep.CALL), this.paren(this.commaSep(parenthizedArgs, Sep.ARGS_BEFORE_COMMA, Sep.ARGS_AFTER_COMMA), Sep.CALL_PAREN_BEFORE, Sep.CALL_PAREN_AFTER, Sep.CALL_PAREN_EMPTY)),
       {
         startsWithCurly: callee.startsWithCurly,
+        startsWithLet: callee.startsWithLet,
         startsWithLetSquareBracket: callee.startsWithLetSquareBracket,
         startsWithFunctionOrClass: callee.startsWithFunctionOrClass,
       }
@@ -1065,6 +1066,7 @@ export class ExtensibleCodeGen {
     state = seq(state, this.t('`'));
     if (node.tag != null) {
       state.startsWithCurly = tag.startsWithCurly;
+      state.startsWithLet = tag.startsWithLet;
       state.startsWithLetSquareBracket = tag.startsWithLetSquareBracket;
       state.startsWithFunctionOrClass = tag.startsWithFunctionOrClass;
     }

--- a/src/minimal-codegen.js
+++ b/src/minimal-codegen.js
@@ -266,6 +266,7 @@ export default class MinimalCodeGen {
       seq(p(node.callee, getPrecedence(node), callee), paren(commaSep(parenthizedArgs))),
       {
         startsWithCurly: callee.startsWithCurly,
+        startsWithLet: callee.startsWithLet,
         startsWithLetSquareBracket: callee.startsWithLetSquareBracket,
         startsWithFunctionOrClass: callee.startsWithFunctionOrClass,
       }
@@ -715,6 +716,7 @@ export default class MinimalCodeGen {
     state = seq(state, t('`'));
     if (node.tag != null) {
       state.startsWithCurly = tag.startsWithCurly;
+      state.startsWithLet = tag.startsWithLet;
       state.startsWithLetSquareBracket = tag.startsWithLetSquareBracket;
       state.startsWithFunctionOrClass = tag.startsWithFunctionOrClass;
     }

--- a/test/simple.js
+++ b/test/simple.js
@@ -672,6 +672,8 @@ describe('Code generator', () => {
       testScript('for((let)of b);');
       testScript('for((let.a)of b);');
       testScript('for((let[a])of b);');
+      testScript('for((let().a)of b);');
+      testScript('for((let``.a)of b);');
       test2Script('for((let.a)of b);', 'for((let).a of b);');
       testModule('for(a of(b,c));');
     });
@@ -794,6 +796,8 @@ describe('Code generator', () => {
       testScript('for((let)in b);');
       testScript('for((let.a)in b);');
       testScript('for((let[a])in b);');
+      testScript('for((let().a)in b);');
+      testScript('for((let``.a)in b);');
       test2Script('for((let.a)in b);', 'for((let).a in b);');
       testScript('for(var a=0 in 1);');
     });


### PR DESCRIPTION
So that `for ((let().a) of b);` codegens correctly.

Includes version bump commit, so please **rebase**, not squash.