### PR TITLE
export more utilities necessary for custom formatters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-codegen",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-codegen",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "code generator for Shift format ASTs",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-codegen-js",

--- a/src/formatted-codegen.js
+++ b/src/formatted-codegen.js
@@ -1359,6 +1359,10 @@ class FormattedCodeGen extends ExtensibleCodeGen {
     }
   }
 }
+FormattedCodeGen.isEmpty = isEmpty;
+FormattedCodeGen.Linebreak = Linebreak;
+FormattedCodeGen.seq = seq;
+FormattedCodeGen.indent = indent;
 
 module.exports = {
   Sep,


### PR DESCRIPTION
The `FormattedCodeGen` class has an `instanceof` tests for `Linebreak`, which means that if you want to add your own `Linebreak` that class needs to be exported. Also exports some helpers.

Includes version bump commit, so please **rebase**, not squash.